### PR TITLE
Add Arc.Ecto.t()

### DIFF
--- a/lib/arc_ecto.ex
+++ b/lib/arc_ecto.ex
@@ -1,2 +1,3 @@
 defmodule Arc.Ecto do
+  @type t :: %{file_name: String.t, updated_at: DateTime.t}
 end


### PR DESCRIPTION
[Quote from original PR](https://github.com/stavro/arc_ecto/pull/79#issue-131905052):
> I’ve added an Arc.Ecto.t type, which can be useful when you want declare a @type for your Ecto schemas containing an Arc-managed file.
>
> For instance:
> ```Elixir
> defmodule MyApp.Something do
>   use Ecto.Schema
>   use Arc.Ecto.Schema
>
>   @type t :: %__MODULE__{
>     name: String.t | nil,
>     some_file: Arc.Ecto.t | nil, # The type is useful here
>   }
>
>   schema "somethings" do
>     field :name, :string
>     field :some_file, MyApp.MyUploader.Type
>
>     timestamps()
>   end
> end
> ```